### PR TITLE
Make Dispatch a namespace and old class Base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@
 *.a
 mkmf.log
 *.gem
+
+# RVM control
+.ruby-version
+.ruby-gemset

--- a/lib/smb2.rb
+++ b/lib/smb2.rb
@@ -4,6 +4,8 @@
 module Smb2
   autoload :VERSION, 'smb2/version'
   autoload :Packet, 'smb2/packet'
+  autoload :Dispatcher, 'smb2/dispatcher'
+  autoload :Client, 'smb2/client'
 
   # [[MS-SMB2] 2.2 Message Syntax](https://msdn.microsoft.com/en-us/library/cc246497.aspx)
   COMMANDS = {

--- a/lib/smb2/dispatcher.rb
+++ b/lib/smb2/dispatcher.rb
@@ -1,16 +1,4 @@
-
-class Smb2::Dispatcher
-
-  # @param packet [#length]
-  # @return [Fixnum] NBSS header to go in front of `packet`
-  def nbss(packet)
-    [packet.length].pack("N")
-  end
-
-  # @abstract
-  def send_packet(packet); raise NotImplementedError; end
-
-  # @abstract
-  def recv_packet; raise NotImplementedError; end
-
+module Smb2::Dispatcher
+  autoload :Base, 'smb2/dispatcher/base'
+  autoload :Socket, 'smb2/dispatcher/socket'
 end

--- a/lib/smb2/dispatcher/base.rb
+++ b/lib/smb2/dispatcher/base.rb
@@ -1,0 +1,14 @@
+class Smb2::Dispatcher::Base
+  # @param packet [#length]
+  # @return [Fixnum] NBSS header to go in front of `packet`
+  def nbss(packet)
+    [packet.length].pack("N")
+  end
+
+  # @abstract
+  def send_packet(packet); raise NotImplementedError; end
+
+  # @abstract
+  def recv_packet; raise NotImplementedError; end
+end
+

--- a/lib/smb2/dispatcher/socket.rb
+++ b/lib/smb2/dispatcher/socket.rb
@@ -1,4 +1,4 @@
-class Smb2::Dispatcher::Socket < Smb2::Dispatcher
+class Smb2::Dispatcher::Socket < Smb2::Dispatcher::Base
 
   # @!attribute [rw] socket
   #   @return [IO]

--- a/lib/smb2/version.rb
+++ b/lib/smb2/version.rb
@@ -9,6 +9,8 @@ module Smb2
     # The patch number, scoped to the {MINOR} version number.
     PATCH = 2
 
+    PRERELEASE='dispatch-as-namespace'
+
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the {PRERELEASE} in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.
     #

--- a/spec/support/mock_socket_dispatcher.rb
+++ b/spec/support/mock_socket_dispatcher.rb
@@ -1,5 +1,5 @@
 require 'smb2/dispatcher'
-class MockSocketDispatcher < Smb2::Dispatcher
+class MockSocketDispatcher < Smb2::Dispatcher::Base
 
   def recv_packet
     ""


### PR DESCRIPTION
Fixes #6

* Also fixes .gitignore to ignore .ruby-version and .ruby-gemset


## Verification
- [ ] `rake spec`
- [ ] Verify: all specs pass
