### PR TITLE
Re-enable rubyntlm upstream

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,4 @@
 source 'https://rubygems.org'
 gemspec
 
-#gem 'rubyntlm', git: 'https://github.com/WinRb/rubyntlm/', branch: 'dan/ntlm-client'
-gem 'rubyntlm', git: 'https://github.com/jlee-r7/rubyntlm/', branch: 'bug/client-domain-encoding'
 gem 'pry'

--- a/lib/smb2/version.rb
+++ b/lib/smb2/version.rb
@@ -7,7 +7,9 @@ module Smb2
     # The minor version number, scoped to the {MAJOR} version number.
     MINOR = 0
     # The patch number, scoped to the {MINOR} version number.
-    PATCH = 2
+    PATCH = 3
+
+    PRERELEASE = 'reenable-ntlm-upstream'
 
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the {PRERELEASE} in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/smb2.gemspec
+++ b/smb2.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "yard"
   spec.add_development_dependency "yard-bit-struct"
 
-  spec.add_runtime_dependency "rubyntlm"
+  spec.add_runtime_dependency "rubyntlm", "~> 0.5"
   spec.add_runtime_dependency "bit-struct"
 
 end


### PR DESCRIPTION
MSP-12224

Upstream landed WinRb/rubyntlm#19, so go back to using upstream instead of my patched repo

## Verification
- [x] `bundle`
- [x] `rake spec`

