### PR TITLE
Rewrite send_packet to avoid assign in conditional

### DIFF
--- a/lib/smb2/dispatcher/socket.rb
+++ b/lib/smb2/dispatcher/socket.rb
@@ -21,8 +21,9 @@ class Smb2::Dispatcher::Socket < Smb2::Dispatcher::Base
   # @return [void]
   def send_packet(packet)
     data = nbss(packet) + packet.to_s
-    while (bytes_written = @socket.write(data)) < data.size
-      data.slice!(0, bytes_written)
+    bytes_written = 0
+    while bytes_written < data.size
+      bytes_written += @socket.write(data[bytes_written..-1])
     end
 
     nil

--- a/lib/smb2/version.rb
+++ b/lib/smb2/version.rb
@@ -9,6 +9,8 @@ module Smb2
     # The patch number, scoped to the {MINOR} version number.
     PATCH = 4
 
+    PRERELEASE = 'avoid-assignment-in-conditional'
+
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.
     #


### PR DESCRIPTION
# Verification
Setup:
- [x] Connect to an SMB2 server (Windows Vista or newer). Replace values below with things that make sense for your target

```ruby
dispatcher = Smb2::Dispatcher::Socket.connect("192.168.100.140", 445)
client = Smb2::Client.new(
  dispatcher: dispatcher,
  username:"administrator",
  password:"P@ssword1",
  domain:"asdfasdf"
)
```
- [x] `client.negotiate` **VERIFY** you get a response with nt_status=0
- [x] `client.authenticate` **VERIFY** nt_status is 0

Tree Connect still works
- [x] `tree = client.tree_connect("\\\\192.168.100.140\\someshare")` **VERIFY** nt_status is 0

Opening a file still works
- [x] `file = tree.create("some_file.txt")` **VERIFY** Smb2::File object with non-zero file_id

Reading still works:
- [x] `file.read` **VERIFY** actual contents of some_file.txt

# Post merge steps
- [x] Remove PRELEASE version