### PR TITLE
Signing for 2.x dialects

### DIFF
--- a/lib/smb2/packet.rb
+++ b/lib/smb2/packet.rb
@@ -408,7 +408,7 @@ class Smb2::Packet < BitStruct
     self
   end
 
-  # Sign this {Packet} with `session_key` and set the {#header}'s
+  # Sign this {Packet} with `session_key` and set the header's
   # {RequestHeader#signature signature}.
   #
   # @param session_key [String] the key to sign with

--- a/lib/smb2/packet.rb
+++ b/lib/smb2/packet.rb
@@ -408,4 +408,25 @@ class Smb2::Packet < BitStruct
     self
   end
 
+  # Sign this {Packet} with `session_key` and set the {#header}'s
+  # {RequestHeader#signature signature}.
+  #
+  # @param session_key [String] the key to sign with
+  # @return [void]
+  def sign!(session_key)
+    hdr = header
+    hdr.signature = "\0"*16
+    hdr.flags |= Smb2::Packet::RequestHeader::FLAGS[:SIGNING]
+
+    self.header = hdr
+
+    hmac = OpenSSL::HMAC.digest(OpenSSL::Digest::SHA256.new, session_key, self.to_s)
+
+    hdr = header
+    hdr.signature = hmac[0, 16]
+    self.header = hdr
+
+    self
+  end
+
 end

--- a/lib/smb2/version.rb
+++ b/lib/smb2/version.rb
@@ -9,6 +9,8 @@ module Smb2
     # The patch number, scoped to the {MINOR} version number.
     PATCH = 4
 
+    PRERELEASE = 'signing'
+
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.
     #

--- a/spec/lib/smb2/packet_spec.rb
+++ b/spec/lib/smb2/packet_spec.rb
@@ -141,4 +141,15 @@ RSpec.describe Smb2::Packet do
 
     end
   end
+
+  describe '#sign!' do
+    let(:key) { "0123456789abcdef" }
+
+    specify do
+      packet.sign!(key)
+      expected = ["e1a453aed1a58529299658224dd1374d"].pack("H*")
+      expect(packet.header.signature).to eq(expected)
+    end
+
+  end
 end


### PR DESCRIPTION
See #41.

Note that this does not implement signing for 3.x dialects

## Verification
- [x] Connect to a box that doesn't require signing (the default for all but domain controllers)
  - [x] watch in wireshark
  - [x] **Verify** you can read and write files
  - [x] **Verify** packets are *not* signed (the `signature` field of SMB2 header is set to zero)
- [x] Connect to a box that requires signing (the default for domain controllers). If you don't have a domain controller, you can force it by changing the `RequireSecuritySignature` setting in the `HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanmanServer\Parameters` registry key to `1`.
  - [x] watch in wireshark
  - [x] **Verify** you can still read/write files
  - [x] **Verify** packets after session setup, starting with TreeConnect are signed (the `signature` field of SMB2 header is set to a non-zero value)