### PR TITLE
Socket#connect now defaults to port 445

### DIFF
--- a/lib/smb2/dispatcher/socket.rb
+++ b/lib/smb2/dispatcher/socket.rb
@@ -8,7 +8,7 @@ class Smb2::Dispatcher::Socket < Smb2::Dispatcher::Base
 
   # @param host [String] passed to TCPSocket.new
   # @param port [Fixnum] passed to TCPSocket.new
-  def self.connect(host, port)
+  def self.connect(host, port=445)
     new(::TCPSocket.new(host, port))
   end
 


### PR DESCRIPTION
 Fixes #45 

## Verification

```ruby
ip = << MY TEST IP >>
dispatcher = Smb2::Dispatcher::Socket.connect(ip)
client = Smb2::Client.new(
  dispatcher: dispatcher,
  username: "Administrator",
  password: "notpassword",
  domain:"WORKSTATION"
)
client.negotiate
client.authenticate
```
- [ ] VERIFY: everything works, no 